### PR TITLE
docs: add security guidelines and workflow ground rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,3 +96,114 @@ cd apps/StorybookApp && pnpm storybook  # localhost:6006
 pnpm biome check .        # 검사
 pnpm biome check --write . # 자동 수정
 ```
+
+## 보안 지침 (공개 레포지토리)
+
+이 프로젝트는 **GitHub 퍼블릭 레포지토리**에 공개되어 있습니다. 아래 규칙을 반드시 준수하세요.
+
+### 절대 커밋하면 안 되는 것들
+
+- `.npmrc` 파일에 포함된 `NPM_TOKEN`, `GITHUB_TOKEN` 등 인증 토큰
+- `.env`, `.env.local`, `.env.*` 시크릿 파일
+- GitHub Actions secrets (`${{ secrets.* }}`) 값 자체
+- 개인 키, 인증서, API 키 등 자격증명 일체
+- 내부 서버 주소, 내부 URL, 내부 인프라 정보
+
+**커밋 전 확인:** `git diff --staged`로 민감 정보가 포함되지 않았는지 검토하세요.
+
+### 의존성 보안
+
+- `pnpm-lock.yaml`을 **항상 커밋**하세요. lockfile 없이 `pnpm install`하지 마세요.
+- 의존성 추가 전 패키지 출처와 다운로드 수를 확인하세요 (타이포스쿼팅 주의).
+- 정기적으로 `pnpm audit`을 실행해 취약점을 점검하세요.
+- 메이저 버전 업그레이드는 changelog를 반드시 검토하세요.
+
+```bash
+pnpm audit          # 취약점 점검
+pnpm audit --fix    # 자동 수정 가능한 취약점 수정
+```
+
+### UI 컴포넌트 보안 (XSS 방지)
+
+이 프로젝트는 UI 라이브러리이므로 사용자 입력을 렌더링하는 컴포넌트에서 XSS가 발생할 수 있습니다.
+
+- `dangerouslySetInnerHTML` 사용을 **금지**합니다. 불가피한 경우 DOMPurify 등으로 sanitize 후 사용하세요.
+- 외부에서 주입된 URL을 `href`나 `src`에 직접 사용하지 마세요. `javascript:` 프로토콜을 차단하세요.
+- `eval()`, `new Function()`, `innerHTML` 직접 조작을 피하세요.
+- React Native에서도 `WebView`에 외부 컨텐츠를 주입할 때 동일한 원칙을 적용하세요.
+
+```tsx
+// 금지
+<div dangerouslySetInnerHTML={{ __html: userInput }} />
+
+// 올바른 방법
+import DOMPurify from 'dompurify'
+<div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(userInput) }} />
+```
+
+### GitHub Actions / CI 보안
+
+- workflow 파일에서 `pull_request_target` 트리거는 신중하게 사용하세요 (포크 PR에서 시크릿 노출 위험).
+- 외부 Actions는 **태그가 아닌 커밋 해시**로 고정하세요.
+- workflow 권한은 최소한으로 설정하세요 (`permissions: read-all` 기본 권장).
+
+```yaml
+# 권장
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+# 비권장 (태그는 변경될 수 있음)
+- uses: actions/checkout@v4
+```
+
+### 배포 / 패키지 보안
+
+- `npm publish` 또는 `pnpm publish`는 CI에서만 실행하고, 로컬에서 직접 배포하지 마세요.
+- 배포 전 `pnpm pack --dry-run`으로 번들에 포함될 파일을 확인하세요.
+- `.npmignore` 또는 `package.json`의 `files` 필드로 소스 외 불필요한 파일이 배포되지 않도록 제한하세요.
+- GitHub Packages 토큰은 **최소 권한**(write:packages만)으로 발급하세요.
+
+### 외부 기여(PR) 검토 시 주의사항
+
+외부 기여자의 PR을 머지하기 전에 반드시 확인하세요:
+
+1. `package.json`의 `scripts` 필드에 악의적인 명령이 추가되지 않았는지
+2. `postinstall`, `prepare` 등 lifecycle script 변경 여부
+3. 새로 추가된 의존성의 신뢰성
+4. `.github/workflows/` 파일 변경 여부 (CI 탈취 시도)
+
+### 보안 취약점 신고
+
+보안 취약점 발견 시 **이슈를 공개적으로 등록하지 말고**, GitHub의 [Security Advisories](https://github.com/coldsurfers/ocean-road/security/advisories/new)를 통해 비공개로 신고해 주세요.
+
+## 작업 그라운드룰 (AI 에이전트 및 기여자 공통)
+
+### 로드맵 이슈 작업 원칙
+
+1. **한 번에 하나의 이슈만 작업합니다.**
+   진행 중인 이슈가 완료(PR 머지)되기 전에 다음 이슈 작업을 시작하지 마세요.
+
+2. **블로킹 의존성을 지킵니다.**
+   이슈에 "선행 작업" 또는 `blockedBy`가 명시된 경우, 해당 이슈가 완료될 때까지 다음 단계로 넘어가지 마세요.
+
+3. **브랜치는 항상 `main` 기준으로 생성합니다.**
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b <브랜치명>
+   ```
+
+4. **브랜치 명명 규칙:** `<타입>/<이슈-요약>`
+   ```
+   docs/setup-rspress-apps-docs     # 이슈 #99
+   docs/getting-started-guide       # 이슈 #100
+   feat/design-tokens-reference     # 이슈 #105
+   ci/s3-cloudfront-deployment      # 이슈 #107
+   ```
+
+5. **하나의 브랜치 = 하나의 이슈 = 하나의 PR.**
+   한 브랜치에 여러 이슈의 변경사항을 섞지 마세요.
+
+6. **PR 생성 전 확인 사항:**
+   - 이슈의 "성공 기준"을 모두 충족했는지 확인
+   - `pnpm biome check .` 통과
+   - 관련 이슈 번호를 PR body에 `Closes #<번호>` 형식으로 명시


### PR DESCRIPTION
## Summary

- **보안 지침 추가**: 공개 레포지토리에서 지켜야 할 보안 규칙 문서화
  - 커밋 금지 항목 (토큰, .env, 자격증명 등)
  - 의존성 보안 (`pnpm audit`, lockfile 관리)
  - UI 컴포넌트 XSS 방지 (`dangerouslySetInnerHTML` 금지 등)
  - GitHub Actions CI 보안 (커밋 해시 고정, 최소 권한)
  - 배포/패키지 보안
  - 외부 기여 PR 검토 체크리스트

- **작업 그라운드룰 추가**: 로드맵 이슈([#108](https://github.com/coldsurfers/ocean-road/issues/108)) 구현 시 AI 에이전트 및 기여자가 따라야 할 워크플로우 규칙
  - 한 번에 하나의 이슈만 작업
  - 블로킹 의존성 준수
  - `main` 기준 브랜치 생성 규칙
  - 브랜치 명명 규칙 (`<타입>/<이슈-요약>`)
  - 1 브랜치 = 1 이슈 = 1 PR 원칙

## Test plan

- [ ] CLAUDE.md 내용이 올바르게 렌더링되는지 확인 (GitHub에서 미리보기)
- [ ] 보안 지침과 그라운드룰 섹션이 기존 내용과 충돌 없이 추가됨

Related: #108