### PR TITLE
fix(docs): correct ColorSchemeToggle example in theming guide

### DIFF
--- a/apps/docs/docs/theming.mdx
+++ b/apps/docs/docs/theming.mdx
@@ -167,18 +167,21 @@ function MyComponent() {
 ## ColorSchemeToggle
 
 `extensions`에서 제공하는 토글 버튼 컴포넌트입니다.
-`GlobalStyle`에 `themeStorageItem`을 지정한 경우, `onToggle` 안에서 `window.__setPreferredTheme`을 호출해 localStorage와 `html.dark` 클래스를 동기화합니다.
+`onToggle`에 전달되는 `setTheme`은 내부적으로 `window.__setPreferredTheme` 호출과 React 상태 업데이트를 모두 처리합니다.
+**`onToggle` 안에서 `window.__setPreferredTheme`을 직접 호출하지 마세요** — 중복 실행됩니다.
 
 ```tsx
-import { ColorSchemeToggle } from '@coldsurfers/ocean-road'
+import { type ColorScheme, ColorSchemeToggle } from '@coldsurfers/ocean-road'
 
 function Header() {
   return (
     <header>
       <ColorSchemeToggle
         onToggle={({ setTheme }) => {
-          const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-          window.__setPreferredTheme?.(next);
+          // localStorage에서 현재 테마를 읽어 다음 테마를 결정
+          const current = localStorage.getItem('@my-app/theme') as ColorScheme;
+          const next: ColorScheme = current === 'dark' ? 'light' : 'dark';
+          // setTheme이 window.__setPreferredTheme + React 상태 업데이트를 함께 처리
           setTheme(next);
         }}
       />
@@ -191,7 +194,7 @@ function Header() {
 
 | prop | 타입 | 필수 | 설명 |
 |------|------|------|------|
-| `onToggle` | `(params: { setTheme: (theme: ColorScheme) => void }) => void` | — | 토글 클릭 시 호출되는 콜백 |
+| `onToggle` | `(params: { setTheme: (theme: ColorScheme) => void }) => void` | — | 토글 클릭 시 호출되는 콜백. `setTheme`은 `window.__setPreferredTheme` + React 상태 업데이트를 포함합니다. |
 
 ---
 


### PR DESCRIPTION
## 문제

`ColorSchemeToggle` 예시 코드에서 `window.__setPreferredTheme`을 수동으로 호출하고 있었으나,
이는 `onToggle`에 전달되는 `setTheme` 내부에서 이미 호출되기 때문에 중복 실행됩니다.

**수정 전 (잘못된 예시):**
```tsx
onToggle={({ setTheme }) => {
  const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
  window.__setPreferredTheme?.(next);  // ← 중복
  setTheme(next);
}}
```

**수정 후 (올바른 예시):**
```tsx
onToggle={({ setTheme }) => {
  const current = localStorage.getItem('@my-app/theme') as ColorScheme;
  const next: ColorScheme = current === 'dark' ? 'light' : 'dark';
  setTheme(next); // window.__setPreferredTheme + React 상태 업데이트 포함
}}
```

## 근거

`color-scheme-toggle.tsx:36-41` — `onToggle`에 전달되는 `setTheme` wrapper:
```ts
setTheme: (theme) => {
  window.__setPreferredTheme(theme); // 내부에서 이미 호출
  setTheme(theme);
}
```