### PR TITLE
docs: add Web base component API reference

### DIFF
--- a/apps/docs/docs/components/badge.mdx
+++ b/apps/docs/docs/components/badge.mdx
@@ -1,0 +1,28 @@
+# Badge
+
+태그/필터 형태의 배지 컴포넌트입니다. 클릭 가능한 항목 선택 UI에 주로 사용합니다.
+
+## 사용법
+
+```tsx
+import { Badge } from '@coldsurfers/ocean-road'
+
+<Badge onClick={() => {}}>라이브</Badge>
+
+// 하이라이트 상태
+<Badge isHighlighted onClick={() => {}}>선택됨</Badge>
+
+// 아이콘 포함
+<Badge leftIcon="Music" onClick={() => {}}>음악</Badge>
+```
+
+## Props
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `children` | `string \| ReactElement` | — | 배지 내용 |
+| `isHighlighted` | `boolean` | — | `true`이면 강조 배경색을 적용합니다. |
+| `leftIcon` | `keyof Icons` | — | 텍스트 왼쪽에 표시될 lucide-react 아이콘 이름 |
+| `onClick` | `() => void` | — | 클릭 핸들러 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-badge--default)

--- a/apps/docs/docs/components/button.mdx
+++ b/apps/docs/docs/components/button.mdx
@@ -1,0 +1,42 @@
+# Button
+
+기본 버튼 컴포넌트입니다. 6가지 variant를 제공하며 아이콘과 함께 사용할 수 있습니다.
+
+## 사용법
+
+```tsx
+import { Button } from '@coldsurfers/ocean-road'
+
+<Button variant="indigo" onClick={() => {}}>
+  확인
+</Button>
+```
+
+## Props
+
+`ButtonHTMLAttributes<HTMLButtonElement>`를 모두 상속합니다.
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `variant` | `'indigo' \| 'pink' \| 'white' \| 'border' \| 'transparent' \| 'transparentDarkGray'` | `'indigo'` | 버튼 색상 테마 |
+| `size` | `'lg' \| 'md' \| 'sm'` | `'md'` | 버튼 크기 |
+| `textWeight` | `'light' \| 'medium' \| 'bold'` | `'medium'` | 텍스트 굵기 |
+| `leftIcon` | `keyof Icons \| ReactElement` | — | 텍스트 왼쪽 아이콘 (lucide-react 이름 또는 ReactElement) |
+| `rightIcon` | `keyof Icons \| ReactElement` | — | 텍스트 오른쪽 아이콘 |
+| `children` | `ReactNode` | — | 버튼 내용 |
+
+## 예시
+
+```tsx
+// 아이콘 포함
+<Button variant="indigo" leftIcon="Search" size="lg">
+  검색
+</Button>
+
+// 비활성화
+<Button variant="border" disabled>
+  비활성화
+</Button>
+```
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-button--indigo)

--- a/apps/docs/docs/components/checkbox.mdx
+++ b/apps/docs/docs/components/checkbox.mdx
@@ -1,0 +1,26 @@
+# Checkbox
+
+체크박스 인풋 컴포넌트입니다. 선택적으로 라벨 텍스트를 함께 표시할 수 있습니다.
+
+## 사용법
+
+```tsx
+import { Checkbox } from '@coldsurfers/ocean-road'
+
+<Checkbox
+  labelText="이용약관에 동의합니다"
+  checked={checked}
+  onChange={(e) => setChecked(e.target.checked)}
+/>
+```
+
+## Props
+
+`InputHTMLAttributes<HTMLInputElement>` (`size`, `formAction` 제외)를 모두 상속합니다.
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `size` | `'lg' \| 'md' \| 'sm'` | `'md'` | 체크박스 크기 |
+| `labelText` | `string` | — | 체크박스 오른쪽에 표시될 라벨 텍스트 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-checkbox--default)

--- a/apps/docs/docs/components/icon-button.mdx
+++ b/apps/docs/docs/components/icon-button.mdx
@@ -1,0 +1,24 @@
+# IconButton
+
+아이콘 전용 버튼 컴포넌트입니다. 텍스트 없이 아이콘만 표시하는 버튼에 사용합니다.
+
+## 사용법
+
+```tsx
+import { IconButton } from '@coldsurfers/ocean-road'
+import { Search } from 'lucide-react'
+
+<IconButton onClick={() => {}}>
+  <Search size={20} />
+</IconButton>
+```
+
+## Props
+
+`ButtonHTMLAttributes<HTMLButtonElement>`를 모두 상속합니다.
+
+| prop | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `children` | `ReactNode` | ✅ | 표시할 아이콘 엘리먼트 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-iconbutton--default)

--- a/apps/docs/docs/components/modal.mdx
+++ b/apps/docs/docs/components/modal.mdx
@@ -1,0 +1,35 @@
+# Modal
+
+dimmed 오버레이와 함께 표시되는 모달 컴포넌트입니다. framer-motion 애니메이션이 적용됩니다.
+
+## 사용법
+
+```tsx
+import { Modal } from '@coldsurfers/ocean-road'
+
+function MyPage() {
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setVisible(true)}>열기</button>
+      <Modal visible={visible} onClose={() => setVisible(false)}>
+        <div style={{ background: 'white', padding: 24, borderRadius: 8 }}>
+          모달 내용
+        </div>
+      </Modal>
+    </>
+  )
+}
+```
+
+## Props
+
+| prop | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `visible` | `boolean` | ✅ | 모달 표시 여부 |
+| `onClose` | `() => void` | ✅ | 오버레이 클릭 시 호출되는 콜백 |
+| `zIndex` | `number` | — | z-index 값. 오버레이가 지정값, 컨텐츠가 `zIndex + 1`로 설정됩니다. |
+| `children` | `ReactNode` | — | 모달 내부 컨텐츠 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-modal--default)

--- a/apps/docs/docs/components/spinner.mdx
+++ b/apps/docs/docs/components/spinner.mdx
@@ -1,0 +1,24 @@
+# Spinner
+
+로딩 상태를 표시하는 스피너 컴포넌트입니다.
+
+## 사용법
+
+```tsx
+import { Spinner } from '@coldsurfers/ocean-road'
+
+// 인라인 스피너
+<Spinner />
+
+// 페이지 전체를 덮는 오버레이 스피너
+<Spinner variant="page-overlay" />
+```
+
+## Props
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `variant` | `'page-overlay'` | — | `'page-overlay'` 지정 시 화면 전체를 덮는 로딩 레이어로 표시됩니다. 미지정 시 인라인 스피너로 렌더링됩니다. |
+| `className` | `string` | — | 커스텀 CSS 클래스 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-spinner--default)

--- a/apps/docs/docs/components/switch.mdx
+++ b/apps/docs/docs/components/switch.mdx
@@ -1,0 +1,32 @@
+# Switch
+
+토글 스위치 컴포넌트입니다. `role="switch"` 접근성 속성이 적용되어 있습니다.
+
+## 사용법
+
+```tsx
+import { Switch } from '@coldsurfers/ocean-road'
+
+function Settings() {
+  const [enabled, setEnabled] = useState(false)
+
+  return (
+    <Switch
+      checked={enabled}
+      onChange={setEnabled}
+    />
+  )
+}
+```
+
+## Props
+
+`ButtonHTMLAttributes<HTMLButtonElement>` (`onChange` 제외)를 모두 상속합니다.
+
+| prop | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `checked` | `boolean` | ✅ | 스위치 켜짐/꺼짐 상태 |
+| `onChange` | `(checked: boolean) => void` | ✅ | 상태 변경 시 호출되는 콜백. 새로운 상태 값을 인자로 받습니다. |
+| `disabled` | `boolean` | — | `true`이면 클릭이 비활성화됩니다. |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-switch--default)

--- a/apps/docs/docs/components/text-area.mdx
+++ b/apps/docs/docs/components/text-area.mdx
@@ -1,0 +1,37 @@
+# TextArea
+
+여러 줄 텍스트 입력 컴포넌트입니다. 선택적으로 라벨과 에러 상태를 표시할 수 있습니다.
+
+## 사용법
+
+```tsx
+import { TextArea } from '@coldsurfers/ocean-road'
+
+<TextArea
+  label="내용"
+  placeholder="내용을 입력하세요"
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  rows={5}
+/>
+
+// 에러 상태
+<TextArea
+  label="내용"
+  isError
+  placeholder="에러 상태"
+/>
+```
+
+## Props
+
+`TextareaHTMLAttributes<HTMLTextAreaElement>`를 모두 상속합니다.
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `label` | `string` | — | 입력 필드 위에 표시될 라벨 텍스트 |
+| `labelStyle` | `CSSProperties` | — | 라벨 인라인 스타일 |
+| `noResize` | `boolean` | `true` | `true`이면 사용자가 크기를 조절할 수 없습니다. |
+| `isError` | `boolean` | — | `true`이면 에러 스타일을 적용합니다. |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-textarea--default)

--- a/apps/docs/docs/components/text-input.mdx
+++ b/apps/docs/docs/components/text-input.mdx
@@ -1,0 +1,62 @@
+# TextInput
+
+한 줄 텍스트 입력 컴포넌트입니다. 라벨, 에러 상태, 좌우 슬롯을 지원합니다.
+
+## 사용법
+
+```tsx
+import { TextInput } from '@coldsurfers/ocean-road'
+import { Search } from 'lucide-react'
+
+<TextInput
+  label="이메일"
+  placeholder="example@email.com"
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
+
+// 좌우 슬롯
+<TextInput
+  placeholder="검색어 입력"
+  left={<Search size={16} />}
+/>
+
+// 에러 상태
+<TextInput
+  label="비밀번호"
+  isError
+  type="password"
+/>
+```
+
+## Props
+
+`InputHTMLAttributes<HTMLInputElement>`를 모두 상속합니다.
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `label` | `string` | — | 입력 필드 위에 표시될 라벨 텍스트 |
+| `labelStyle` | `CSSProperties` | — | 라벨 인라인 스타일 |
+| `isError` | `boolean` | — | `true`이면 에러 스타일을 적용합니다. |
+| `required` | `boolean` | — | `true`이면 라벨에 필수 표시를 추가합니다. |
+| `left` | `ReactNode` | — | 입력 필드 왼쪽 슬롯 (아이콘 등) |
+| `right` | `ReactNode` | — | 입력 필드 오른쪽 슬롯 |
+
+## ref
+
+`useRef<TextInputRef>`로 프로그래매틱 제어가 가능합니다.
+
+```tsx
+import { useRef } from 'react'
+import { TextInput, type TextInputRef } from '@coldsurfers/ocean-road'
+
+const inputRef = useRef<TextInputRef>(null)
+
+<TextInput ref={inputRef} placeholder="..." />
+
+// 포커스 / 블러
+inputRef.current?.focus()
+inputRef.current?.blur()
+```
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-textinput--default)

--- a/apps/docs/docs/components/text.mdx
+++ b/apps/docs/docs/components/text.mdx
@@ -1,0 +1,30 @@
+# Text
+
+텍스트 렌더링 컴포넌트입니다. 기본 엘리먼트는 `<span>`이며 `as` prop으로 변경할 수 있습니다.
+
+## 사용법
+
+```tsx
+import { Text } from '@coldsurfers/ocean-road'
+
+<Text>기본 텍스트</Text>
+
+<Text as="h1">제목</Text>
+
+<Text as="p" numberOfLines={2}>
+  긴 텍스트를 두 줄로 제한합니다. 초과하는 내용은 말줄임표로 처리됩니다.
+</Text>
+```
+
+## Props
+
+`ComponentPropsWithRef<'span'>`을 모두 상속합니다.
+
+| prop | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `as` | `ElementType` | `'span'` | 렌더링할 HTML 엘리먼트 또는 컴포넌트 (`'p'`, `'h1'`, `'div'` 등) |
+| `numberOfLines` | `number` | — | 최대 표시 줄 수. 초과 시 말줄임표(`…`) 처리 |
+| `style` | `CSSProperties` | — | 인라인 스타일 |
+| `children` | `ReactNode` | — | 텍스트 내용 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-text--default)

--- a/apps/docs/docs/components/toast.mdx
+++ b/apps/docs/docs/components/toast.mdx
@@ -1,0 +1,43 @@
+# Toast
+
+화면 하단에 잠시 표시되는 알림 컴포넌트입니다. 3초 후 자동으로 닫힙니다.
+
+:::tip
+`Toast`는 반드시 framer-motion의 `AnimatePresence`로 감싸야 진입/퇴장 애니메이션이 동작합니다.
+:::
+
+## 사용법
+
+```tsx
+import { useState } from 'react'
+import { AnimatePresence } from 'framer-motion'
+import { Toast, Button } from '@coldsurfers/ocean-road'
+
+function MyPage() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <Button onClick={() => setShow(true)}>토스트 표시</Button>
+      <AnimatePresence>
+        {show && (
+          <Toast
+            message="저장되었습니다."
+            onClose={() => setShow(false)}
+          />
+        )}
+      </AnimatePresence>
+    </>
+  )
+}
+```
+
+## Props
+
+| prop | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `message` | `string` | ✅ | — | 표시할 메시지 텍스트 |
+| `onClose` | `() => void` | ✅ | — | 3초 경과 또는 클릭 시 호출되는 콜백 |
+| `zIndex` | `number` | — | `99` | z-index 값 |
+
+[Storybook에서 보기 →](https://storybook.ocean-road.coldsurf.io/?path=/story/base-toast--default)

--- a/apps/docs/rspress.config.ts
+++ b/apps/docs/rspress.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
         content: 'https://github.com/coldsurfers/ocean-road',
       },
     ],
-    nav: [{ text: '가이드', link: '/installation' }],
+    nav: [
+      { text: '가이드', link: '/installation' },
+      { text: '컴포넌트', link: '/components/button' },
+    ],
     sidebar: {
       '/': [
         {
@@ -21,6 +24,22 @@ export default defineConfig({
           items: [
             { text: '설치', link: '/installation' },
             { text: '테마', link: '/theming' },
+          ],
+        },
+        {
+          text: '컴포넌트 (Web)',
+          items: [
+            { text: 'Badge', link: '/components/badge' },
+            { text: 'Button', link: '/components/button' },
+            { text: 'Checkbox', link: '/components/checkbox' },
+            { text: 'IconButton', link: '/components/icon-button' },
+            { text: 'Modal', link: '/components/modal' },
+            { text: 'Spinner', link: '/components/spinner' },
+            { text: 'Switch', link: '/components/switch' },
+            { text: 'Text', link: '/components/text' },
+            { text: 'TextArea', link: '/components/text-area' },
+            { text: 'TextInput', link: '/components/text-input' },
+            { text: 'Toast', link: '/components/toast' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary

`packages/ocean-road/src/base/` 소스 코드 기반으로 11개 base 컴포넌트 API 레퍼런스 문서 작성.

### 추가된 페이지

| 컴포넌트 | 파일 |
|---------|------|
| Badge | `docs/components/badge.mdx` |
| Button | `docs/components/button.mdx` |
| Checkbox | `docs/components/checkbox.mdx` |
| IconButton | `docs/components/icon-button.mdx` |
| Modal | `docs/components/modal.mdx` |
| Spinner | `docs/components/spinner.mdx` |
| Switch | `docs/components/switch.mdx` |
| Text | `docs/components/text.mdx` |
| TextArea | `docs/components/text-area.mdx` |
| TextInput | `docs/components/text-input.mdx` |
| Toast | `docs/components/toast.mdx` |

각 페이지 포함 내용: props 테이블 + 사용 예시 + Storybook 링크

`rspress.config.ts`에 nav(`컴포넌트`) 및 sidebar(`컴포넌트 (Web)`) 섹션 추가.

## 성공 기준 확인

- [x] 11개 컴포넌트 페이지 전부 존재
- [x] `build/components/*.html` 11개 생성 확인
- [x] 각 페이지 props 테이블 + 코드 예시 + Storybook 링크 포함

Closes #102