### PR TITLE
ci: deploy docs site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,16 +1,23 @@
 name: Deploy Docs
+
 on:
-    workflow_dispatch:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  id-token: write # OIDC
   contents: read
+  pages: write
+  id-token: write
   packages: read
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,23 +27,24 @@ jobs:
         with:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build Docs
         run: pnpm turbo run build --filter=@coldsurfers/docs
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ap-northeast-2
+          path: ./apps/docs/build
 
-      - name: Upload docs build to S3
-        working-directory: ./apps/docs
-        run: |
-          aws s3 sync build s3://${{ secrets.DOCS_S3_BUCKET }} \
-            --delete
-
-      - name: Invalidate CloudFront cache
-        run: |
-            aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.DOCS_CLOUDFRONT_ID }} \
-            --paths "/*"
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/docs/docs/public/CNAME
+++ b/apps/docs/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.ocean-road.coldsurf.io

--- a/apps/docs/rspress.config.ts
+++ b/apps/docs/rspress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'rspress/config';
 
 export default defineConfig({
   root: 'docs',
+  base: '/',
   title: 'Ocean Road',
   description: 'COLDSURF 디자인 시스템 컴포넌트 라이브러리',
   outDir: 'build',


### PR DESCRIPTION
## Summary

- S3/CloudFront 배포 방식을 GitHub Pages로 전환
- `push: [main]` 트리거 추가로 main 머지 시 자동 배포
- 커스텀 도메인 `docs.ocean-road.coldsurf.io` 설정 (CNAME 파일 + `base: '/'`)

## 변경 파일

- `.github/workflows/deploy-docs.yml` — AWS → GitHub Pages Actions으로 교체
- `apps/docs/rspress.config.ts` — `base: '/'` 추가 (커스텀 도메인용)
- `apps/docs/docs/public/CNAME` — `docs.ocean-road.coldsurf.io` 등록

## 배포 후 남은 작업

1. GitHub Repo Settings → Pages → Source → **GitHub Actions** 선택
2. 워크플로우 최초 실행 (Actions 탭 → `Deploy Docs` → Run workflow)
3. 배포 완료 후 Settings → Pages → Custom domain → `docs.ocean-road.coldsurf.io` 입력
4. DNS: `docs.ocean-road CNAME coldsurfers.github.io` 레코드 추가

Closes #107