### PR TITLE
fix(design-tokens): 다크 모드 background[1] 을 #0e0e10 으로 완화

### DIFF
--- a/.changeset/soften-dark-background-1.md
+++ b/.changeset/soften-dark-background-1.md
@@ -1,0 +1,6 @@
+---
+'@coldsurfers/ocean-road-design-tokens': patch
+'@coldsurf/ocean-road': patch
+---
+
+`semantics.color.background[1]` dark 값을 `#000000` 에서 `#0e0e10` 으로 변경 — 순흑색이 다크 모드 UI 와 이질감 있다는 피드백 반영. 다른 배경 단계(`background[2]` 이상)와의 점프도 자연스러워짐.

--- a/.changeset/soften-dark-background-1.md
+++ b/.changeset/soften-dark-background-1.md
@@ -1,5 +1,4 @@
 ---
-'@coldsurfers/ocean-road-design-tokens': patch
 '@coldsurf/ocean-road': patch
 ---
 

--- a/packages/ocean-road-design-tokens/tokens/color/theme-alias.json
+++ b/packages/ocean-road-design-tokens/tokens/color/theme-alias.json
@@ -3,7 +3,7 @@
     "background": {
       "1": {
         "value": "{oc.white}",
-        "darkValue": "{oc.black}",
+        "darkValue": "#0e0e10",
         "comment": "background color 1"
       },
       "2": {


### PR DESCRIPTION
순흑색(#000000)이 다크 모드 UI 와 어울리지 않는다는 피드백 반영.
oc.black 팔레트 primitive 는 유지하고 background.1.darkValue 만 리터럴 #0e0e10 로 교체.